### PR TITLE
Enhancements for getting job urls for instance status

### DIFF
--- a/oozie/src/main/java/org/apache/falcon/workflow/engine/OozieWorkflowEngine.java
+++ b/oozie/src/main/java/org/apache/falcon/workflow/engine/OozieWorkflowEngine.java
@@ -105,7 +105,7 @@ public class OozieWorkflowEngine extends AbstractWorkflowEngine {
 
     public static final List<String> PARENT_WF_ACTION_NAMES = Arrays.asList(
             "pre-processing",
-            "should-record",
+            "recordsize",
             "succeeded-post-processing",
             "failed-post-processing"
     );
@@ -604,13 +604,13 @@ public class OozieWorkflowEngine extends AbstractWorkflowEngine {
                 }
             } else if (!action.getType().startsWith(":")) {
                 if (PARENT_WF_ACTION_NAMES.contains(action.getName())
-                        && !StringUtils.equals(action.getExternalId(), "-")
                         && !Status.SUCCEEDED.toString().equals(action.getExternalStatus())) {
                     InstancesResult.InstanceAction instanceAction =
                             new InstancesResult.InstanceAction(action.getName(), action.getExternalStatus(),
                                     action.getConsoleUrl());
                     instanceActions.add(instanceAction);
-                } else if (!PARENT_WF_ACTION_NAMES.contains(action.getName())) {
+                } else if (!PARENT_WF_ACTION_NAMES.contains(action.getName())
+                        && !StringUtils.equals(action.getExternalId(), "-")) {
                     InstancesResult.InstanceAction instanceAction =
                             new InstancesResult.InstanceAction(action.getName(), action.getExternalStatus(),
                                     action.getConsoleUrl());


### PR DESCRIPTION
Support getting job urls for older versions of oozie and call the geturl() function only for instance status
