### PR TITLE
Obtain locks on entity & dependents during entity update.

### DIFF
--- a/common/src/main/java/org/apache/falcon/entity/lock/MemoryLocks.java
+++ b/common/src/main/java/org/apache/falcon/entity/lock/MemoryLocks.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.falcon.entity.lock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * In memory resource locking that provides lock capabilities.
+ */
+public class MemoryLocks {
+    private static final Logger LOG = LoggerFactory.getLogger(MemoryLocks.class);
+    private Map<String, ReentrantLock> locks = new ConcurrentHashMap<String, ReentrantLock>();
+
+    /**
+     * Token object is issued when an entity update is invoked.
+     */
+    public class LockToken {
+
+        private final ReentrantLock lock;
+        private final String entityName;
+
+        public String getEntityName() {
+            return entityName;
+        }
+
+        public ReentrantLock getLock() {
+            return lock;
+        }
+
+        LockToken(String entityName, ReentrantLock lock) {
+            this.entityName = entityName;
+            this.lock = lock;
+        }
+
+        /**
+         * Release the lock.
+         */
+        public void release() {
+            synchronized (locks) {
+                locks.remove(this.getEntityName());
+
+                this.getLock().unlock();
+            }
+        }
+    }
+
+
+    /**
+     * Return the number of active locks.
+     *
+     * @return the number of active locks.
+     */
+    public int size() {
+        return locks.size();
+    }
+
+    /**
+     * Obtain a lock for a source.
+     *
+     * @param entityName resource name.
+     * @return the lock token for the resource, or <code>null</code> if the lock could not be obtained.
+     * @throws InterruptedException thrown if the thread was interrupted while waiting.
+     */
+    /**
+     * Acquire a lock for a given entity name.
+     */
+    public LockToken getLock(String entityName) throws InterruptedException {
+        ReentrantLock lockEntry;
+
+        synchronized (locks) {
+            if (locks.containsKey(entityName)) {
+                return null;
+            } else {
+                lockEntry = new ReentrantLock(true);
+                locks.put(entityName, lockEntry);
+            }
+            if (lockEntry.tryLock()) {
+                LOG.info("Lock obtained for update of " + entityName + " by " + Thread.currentThread().getName());
+                return new LockToken(entityName, lockEntry);
+            } else {
+                return null;
+            }
+
+        }
+    }
+
+}

--- a/common/src/main/java/org/apache/falcon/entity/store/ConfigurationStore.java
+++ b/common/src/main/java/org/apache/falcon/entity/store/ConfigurationStore.java
@@ -20,6 +20,7 @@ package org.apache.falcon.entity.store;
 
 import org.apache.commons.codec.CharEncoding;
 import org.apache.falcon.FalconException;
+import org.apache.falcon.entity.lock.MemoryLocks;
 import org.apache.falcon.entity.v0.Entity;
 import org.apache.falcon.entity.v0.EntityType;
 import org.apache.falcon.hadoop.HadoopClientFactory;
@@ -70,6 +71,8 @@ public final class ConfigurationStore implements FalconService {
 
     private final Map<EntityType, ConcurrentHashMap<String, Entity>> dictionary
         = new HashMap<EntityType, ConcurrentHashMap<String, Entity>>();
+
+    private final MemoryLocks locks = new MemoryLocks();
 
     private final FileSystem fs;
     private final Path storePath;
@@ -362,6 +365,19 @@ public final class ConfigurationStore implements FalconService {
 
     public void cleanupUpdateInit() {
         updatesInProgress.set(null);
+    }
+
+    public MemoryLocks.LockToken getUpdateLock(Entity entity) throws InterruptedException {
+        String lockKey = entity.getEntityType().toString() + "." + entity.getName();
+        return locks.getLock(lockKey);
+    }
+    public void releaseUpdateLock(MemoryLocks.LockToken lockToken) {
+        if (lockToken != null) {
+            LOG.info("Releasing update lock for entity " + lockToken.getEntityName());
+            lockToken.release();
+        } else {
+            LOG.info("No update lock to be released");
+        }
     }
 
     @Override

--- a/webapp/src/test/java/org/apache/falcon/resource/EntityManagerJerseyIT.java
+++ b/webapp/src/test/java/org/apache/falcon/resource/EntityManagerJerseyIT.java
@@ -813,4 +813,38 @@ public class EntityManagerJerseyIT {
         cal.set(Calendar.MILLISECOND, 0);
         return cal.getTime();
     }
+
+    @Test
+    public void testMultipleUpdateCommands() throws Exception {
+        //schedule a process
+        TestContext context = newContext();
+        context.scheduleProcess();
+        OozieTestUtils.waitForBundleStart(context, Job.Status.RUNNING);
+        List<BundleJob> bundles = OozieTestUtils.getBundles(context);
+        Assert.assertEquals(bundles.size(), 1);
+
+        //update process should create new bundle
+        Process process = (Process) getDefinition(context, EntityType.PROCESS, context.processName);
+        String feed3 = "f3" + System.currentTimeMillis();
+        Map<String, String> overlay = new HashMap<String, String>();
+        overlay.put("inputFeedName", feed3);
+        overlay.put("cluster", context.clusterName);
+        overlay.put("user", System.getProperty("user.name"));
+        ClientResponse response = context.submitToFalcon(TestContext.FEED_TEMPLATE1, overlay, EntityType.FEED);
+        context.assertSuccessful(response);
+        Input input = new Input();
+        input.setFeed(feed3);
+        input.setName("inputData2");
+        input.setStart("today(20,0)");
+        input.setEnd("today(20,20)");
+        process.getInputs().getInputs().add(input);
+        updateEndtime(process);
+        response = update(context, process, null);
+        //issuing second update command
+        ClientResponse duplicateUpdateCommandResponse = update(context, process, null);
+        context.assertSuccessful(response);
+        context.assertSuccessful(duplicateUpdateCommandResponse);
+        bundles = OozieTestUtils.getBundles(context);
+        Assert.assertEquals(bundles.size(), 2);
+    }
 }


### PR DESCRIPTION
This is to avoid spawning multiple coordinators from multiple update commands